### PR TITLE
Use xmldocs, conform comments to MS recommendations

### DIFF
--- a/src/BitArray.cs
+++ b/src/BitArray.cs
@@ -2,7 +2,7 @@
 
 namespace GolombCodeFilterSet
 {
-	// Manages an array of bits allowing making bit-level operations as a big array of bits
+	/// <summary> Manages an array of bits allowing making bit-level operations as a big array of bits. </summary>
 	public sealed class BitArray
 	{
 		private uint[] _buffer;
@@ -128,7 +128,7 @@ namespace GolombCodeFilterSet
 
 		public void SetBits(int index, ulong val, int count)
 		{
-			//TODO: improve this method. This is a very naive approach
+			// TODO: improve this method. This is a very naive approach.
 			for (var i = 0; i < count; i++)
 			{
 				SetBit(index+i, (val & (1UL << i)) != 0);

--- a/src/BitStream.cs
+++ b/src/BitStream.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 namespace GolombCodeFilterSet
 {
-	// Provides a view of an array of bits as a stream of bits
+	/// <summary> Provides a view of an array of bits as a stream of bits. </summary>
 	internal class BitStream
 	{
 		private readonly BitArray _buffer;

--- a/src/Filter.cs
+++ b/src/Filter.cs
@@ -18,9 +18,12 @@ namespace GolombCodeFilterSet
 		}
 	}
 
-	// Implements a Golomb-coded set to be use in the creation of client-side filter
-	// for a new kind Bitcoin light clients. This code is based on the BIP:
-	// https://github.com/Roasbeef/bips/blob/master/gcs_light_client.mediawiki
+
+	/// <summary>
+	/// Implements a Golomb-coded set to be use in the creation of client-side filter
+	/// for a new kind Bitcoin light clients. This code is based on the BIP:
+	/// https://github.com/Roasbeef/bips/blob/master/gcs_light_client.mediawiki
+	/// </summary>
 	public class Filter
 	{
 		public byte P { get; internal set; }
@@ -32,7 +35,7 @@ namespace GolombCodeFilterSet
 		
 		public static Filter Build(byte[] k, byte P, IEnumerable<byte[]> data)
 		{
-			// NOTE: P must be a power of two as we target the specialized case of Golomb coding: Golomb - Rice coding
+			// NOTE: P must be a power of two as we target the specialized case of Golomb coding: Golomb - Rice coding.
 			if (P == 0x00 || (P & (P - 1)) != 0)
 				throw new ArgumentException("P has to be a power of two value", nameof(P));
 
@@ -58,18 +61,18 @@ namespace GolombCodeFilterSet
 
 		private static List<ulong> ConstructHashedSet(byte P, byte[] key, IEnumerable<byte[]> data)
 		{
-			// N the number of items to be inserted into the set
+			// N the number of items to be inserted into the set.
 			var dataArrayBytes = data as byte[][] ?? data.ToArray();
 			var N = dataArrayBytes.Count();
 
-			// The list of data item hashes
+			// The list of data item hashes.
 			var values = new ConcurrentBag<ulong>();
 			var modP = 1UL << P;
 			var modNP = ((ulong)N) * modP;
 			var nphi = modNP >> 32;
 			var nplo = (ulong)((uint)modNP);
 
-			// Process the data items and calculate the 64 bits hash for each of them
+			// Process the data items and calculate the 64 bits hash for each of them.
 			Parallel.ForEach(dataArrayBytes, item =>
 			{
 				var hash = SipHasher.Hash(key, item);
@@ -144,7 +147,7 @@ namespace GolombCodeFilterSet
 					return true;
 			}
 			catch (ArgumentOutOfRangeException)
-			// This means we reached the end of the bits stream ao, the value was not found
+			// This means we reached the end of the bits stream ao, the value was not found.
 			{
 				return false;
 			}
@@ -190,8 +193,7 @@ namespace GolombCodeFilterSet
 
 		private static ulong FastReduction(ulong value, ulong nhi, ulong nlo)
 		{
-			// First, we'll spit the item we need to reduce into its higher and
-			// lower bits.
+			// First, we'll spit the item we need to reduce into its higher and lower bits.
 			var vhi = value >> 32;
 			var vlo = (ulong)((uint)value);
 

--- a/tests/BitArrayTest.cs
+++ b/tests/BitArrayTest.cs
@@ -29,12 +29,12 @@ namespace GolombCodedFilterSet.UnitTests
 				}
 			}
 
-			// Get bits in the same int
+			// Get bits in the same int.
 			Assert.AreEqual((ulong) 0b111, barr.GetBits(0, 3));
 			Assert.AreEqual((ulong) 0b10111, barr.GetBits(0, 5));
 			Assert.AreEqual((ulong) 0b01010111010, barr.GetBits(3, 11));
 
-			// Get bits in cross int
+			// Get bits in cross int.
 			Assert.AreEqual((ulong) 0b101110101110101, barr.GetBits(24, 16));
 		}
 

--- a/tests/BuilderTest.cs
+++ b/tests/BuilderTest.cs
@@ -17,22 +17,22 @@ namespace GolombCodedFilterSet.UnitTests
 			var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 			var filter = Filter.Build(key, 0x10, names);
 
-			// The filter should match all ther values that were added
+			// The filter should match all ther values that were added.
 			foreach(var name in names)
 			{
 				Assert.IsTrue(filter.Match(name, key));
 			}
 
-			// The filter should NOT match any extra value
+			// The filter should NOT match any extra value.
 			Assert.IsFalse(filter.Match(Encoding.ASCII.GetBytes("Porto Alegre"), key));
 			Assert.IsFalse(filter.Match(Encoding.ASCII.GetBytes("Madrid"), key));
 
-			// The filter should match because it has one element indexed: Buenos Aires
+			// The filter should match because it has one element indexed: Buenos Aires.
 			var otherCities = new[] { "La Paz", "Barcelona", "El Cairo", "Buenos Aires", "Asunción" };
 			var otherNames = from name in otherCities select Encoding.ASCII.GetBytes(name);
 			Assert.IsTrue(filter.MatchAny(otherNames, key));
 
-			// The filter should NOT match because it doesn't have any element indexed
+			// The filter should NOT match because it doesn't have any element indexed.
 			var otherCities2 = new[] { "La Paz", "Barcelona", "El Cairo", "Córdoba", "Asunción" };
 			var otherNames2 = from name in otherCities2 select Encoding.ASCII.GetBytes(name);
 			Assert.IsFalse(filter.MatchAny(otherNames2, key));

--- a/tests/PerformanceTest.cs
+++ b/tests/PerformanceTest.cs
@@ -21,15 +21,15 @@ namespace GolombCodedFilterSet.UnitTests
 			// per block.
 			const int blockCount = 100;
 			const int maxBlockSize = 4 * 1000 * 1000;
-			const int avgTxSize = 250;					// currently the average is around 1kb
+			const int avgTxSize = 250;					// Currently the average is around 1kb.
 			const int txoutCountPerBlock = maxBlockSize / avgTxSize;
 			const int txoutCountTotal = txoutCountPerBlock * blockCount;
-			const int avgTxoutPushDataSize = 20;		// P2PKH scripts has 20 bytes
+			const int avgTxoutPushDataSize = 20;		// P2PKH scripts has 20 bytes.
 			const int walletAddressCount = 1000;        // We estimate that our user will have 1000 addresses.
 
 			var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
-			// Generation of data to be added into the filter
+			// Generation of data to be added into the filter.
 			var random = new Random();
 
 			var blocks= new List< (Filter, List<byte[]>)>(blockCount);
@@ -48,7 +48,7 @@ namespace GolombCodedFilterSet.UnitTests
 			}
 
 
-			// Check that the filter can match every single txout in every block
+			// Check that the filter can match every single txout in every block.
 			foreach (var block in blocks)
 			{
 				var filter = block.Item1;
@@ -68,7 +68,7 @@ namespace GolombCodedFilterSet.UnitTests
 				walletAddresses.Add(walletAddress);
 			}
 
-			// Check that the filter can match every single txout in every block
+			// Check that the filter can match every single txout in every block.
 			foreach (var block in blocks)
 			{
 				var filter = block.Item1;


### PR DESCRIPTION
XML docs lets you see into a function/class etc, when you are using the API from the outside.

Microsoft recommends comments to be proper sentences with proper punctuation.

Note: It's just another small commit, this is my way to get familiar with the code, so don't think I care about these much.